### PR TITLE
Fix/set custom access token revoking db permissions

### DIFF
--- a/src/utils/create-multi-tenant-auth-hooks/create-multi-tenant-auth-hooks.test.ts
+++ b/src/utils/create-multi-tenant-auth-hooks/create-multi-tenant-auth-hooks.test.ts
@@ -59,10 +59,6 @@ grant all
   on table public.${userRolesTable}
   to supabase_auth_admin;
 
-revoke all
-  on table public.${userRolesTable}
-  from authenticated, anon, public;
-
 create policy "allow_supabase_auth_admin_to_select_${userRolesTable}" ON public.${userRolesTable} 
 as permissive for select
 to supabase_auth_admin

--- a/src/utils/create-multi-tenant-auth-hooks/create-multi-tenant-auth-hooks.ts
+++ b/src/utils/create-multi-tenant-auth-hooks/create-multi-tenant-auth-hooks.ts
@@ -54,10 +54,6 @@ grant all
   on table public.${userRolesTable}
   to supabase_auth_admin;
 
-revoke all
-  on table public.${userRolesTable}
-  from authenticated, anon, public;
-
 create policy "allow_supabase_auth_admin_to_select_${userRolesTable}" ON public.${userRolesTable} 
 as permissive for select
 to supabase_auth_admin

--- a/src/utils/get-policy-qualification/get-policy-qualification.ts
+++ b/src/utils/get-policy-qualification/get-policy-qualification.ts
@@ -58,7 +58,7 @@ const getPolicyQualification = ({
       AUTHENTICATED: 'WITH CHECK ( true )',
       USER_IS_OWNER: 'WITH CHECK ( (select auth.uid()) = user_id )',
       HAS_ROLE: `WITH CHECK ( ${tenantsTable ? tenantRoleCheck.multiTenant : tenantRoleCheck.singleTenant} )`,
-      BELONGS_TENANT: `USING ( ${tenantMemberCheck} )`,
+      BELONGS_TENANT: `WITH CHECK ( ${tenantMemberCheck} )`,
     },
   };
 


### PR DESCRIPTION
- Fix `set_custom_access_token` auth hook revoking permissions from `anon`, `authenticated` and `public` users. This is required for RLS policies to work.
- Fix `INSERT` for `belongsTenant()` to have a `WITH CHECK` rather than `USING` clause.